### PR TITLE
Experiment: error type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,19 +28,18 @@ impl std::fmt::Display for Error {
 
 impl StdError for Error {}
 
-#[derive(Debug)]
-pub struct Router {
-    inner: HashMap<Method, InnerRouter<Box<dyn Handler>>>,
-    not_found: Option<Box<dyn Handler>>,
+pub struct Router<E: Into<Box<dyn StdError + Send + Sync>> + 'static> {
+    inner: HashMap<Method, InnerRouter<Box<dyn Handler<E>>>>,
+    not_found: Option<Box<dyn Handler<E>>>,
 }
 
-impl Default for Router {
+impl<E: Into<Box<dyn StdError + Send + Sync>> + 'static> Default for Router<E> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Router {
+impl<E: Into<Box<dyn StdError + Send + Sync>> + 'static> Router<E> {
     pub fn new() -> Self {
         Self {
             inner: HashMap::new(),
@@ -49,59 +48,97 @@ impl Router {
     }
 
     /// Register a handler for GET requests
-    pub fn get(&mut self, path: &str, handler: impl Handler) {
+    pub fn get<H, R>(&mut self, path: &str, handler: H)
+    where
+        H: Fn(Request<Body>) -> R + Send + Sync + 'static,
+        R: Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync + 'static,
+        E: Into<Box<dyn StdError + Send + Sync>> + 'static,
+    {
+        let h = move |req| Box::pin(handler(req));
         let entry = self
             .inner
             .entry(Method::GET)
             .or_insert_with(InnerRouter::new);
-        entry.add(path, Box::new(handler));
+        entry.add(path, Box::new(h));
     }
 
     /// Register a handler for POST requests
-    pub fn post(&mut self, path: &str, handler: impl Handler) {
+    pub fn post<H, R>(&mut self, path: &str, handler: H)
+    where
+        H: Fn(Request<Body>) -> R + Send + Sync + 'static,
+        R: Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync + 'static,
+        E: Into<Box<dyn StdError + Send + Sync>> + 'static,
+    {
+        let h = move |req| Box::pin(handler(req));
         let entry = self
             .inner
             .entry(Method::POST)
             .or_insert_with(InnerRouter::new);
-        entry.add(path, Box::new(handler));
+        entry.add(path, Box::new(h));
     }
 
     /// Register a handler for PUT requests
-    pub fn put(&mut self, path: &str, handler: impl Handler) {
+    pub fn put<H, R>(&mut self, path: &str, handler: H)
+    where
+        H: Fn(Request<Body>) -> R + Send + Sync + 'static,
+        R: Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync + 'static,
+        E: Into<Box<dyn StdError + Send + Sync>> + 'static,
+    {
+        let h = move |req| Box::pin(handler(req));
         let entry = self
             .inner
             .entry(Method::PUT)
             .or_insert_with(InnerRouter::new);
-        entry.add(path, Box::new(handler));
+        entry.add(path, Box::new(h));
     }
 
     /// Register a handler for DELETE requests
-    pub fn delete(&mut self, path: &str, handler: impl Handler) {
+    pub fn delete<H, R>(&mut self, path: &str, handler: H)
+    where
+        H: Fn(Request<Body>) -> R + Send + Sync + 'static,
+        R: Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync + 'static,
+        E: Into<Box<dyn StdError + Send + Sync>> + 'static,
+    {
+        let h = move |req| Box::pin(handler(req));
         let entry = self
             .inner
             .entry(Method::DELETE)
             .or_insert_with(InnerRouter::new);
-        entry.add(path, Box::new(handler));
+        entry.add(path, Box::new(h));
     }
 
     /// Register a handler for PATCH requests
-    pub fn patch(&mut self, path: &str, handler: impl Handler) {
+    pub fn patch<H, R>(&mut self, path: &str, handler: H)
+    where
+        H: Fn(Request<Body>) -> R + Send + Sync + 'static,
+        R: Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync + 'static,
+        E: Into<Box<dyn StdError + Send + Sync>> + 'static,
+    {
+        let h = move |req| Box::pin(handler(req));
         let entry = self
             .inner
             .entry(Method::PATCH)
             .or_insert_with(InnerRouter::new);
-        entry.add(path, Box::new(handler));
+        entry.add(path, Box::new(h));
     }
 
     /// Register a handler when no routes are matched
-    pub fn not_found(&mut self, handler: impl Handler) {
+    pub fn not_found<H, R>(&mut self, handler: H)
+    where
+        H: Fn(Request<Body>) -> R + Send + Sync + 'static,
+        R: Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync + 'static,
+        E: Into<Box<dyn StdError + Send + Sync>> + 'static,
+    {
         self.not_found = Some(Box::new(handler));
     }
 
     pub fn serve(
         &self,
         mut req: Request<Body>,
-    ) -> Pin<Box<dyn Future<Output = Result<Response<Body>>> + Send + Sync>> {
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync>>
+    where
+        E: Into<Box<dyn StdError + Send + Sync>> + 'static,
+    {
         match self.inner.get(req.method()) {
             Some(inner_router) => match inner_router.recognize(req.uri().path()) {
                 Ok(matcher) => {
@@ -123,48 +160,52 @@ impl Router {
         }
     }
 
-    pub fn into_service(self) -> MakeRouterService<RouterService> {
+    pub fn into_service(self) -> MakeRouterService<RouterService<E>> {
         MakeRouterService {
             inner: RouterService::new(self),
         }
     }
 }
 
-pub trait Handler: Send + Sync + 'static {
+pub trait Handler<E: Into<Box<dyn StdError + Send + Sync>>>: Send + Sync + 'static {
     fn call(
         &self,
         req: Request<Body>,
-    ) -> Pin<Box<dyn Future<Output = Result<Response<Body>>> + Send + Sync>>;
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync>>;
 }
 
-impl<F: Send + Sync + 'static, R> Handler for F
+impl<F: Send + Sync + 'static, R, E> Handler<E> for F
 where
     F: Fn(Request<Body>) -> R + Send + Sync,
-    R: Future<Output = Result<Response<Body>>> + Send + Sync + 'static,
+    R: Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync + 'static,
+    E: Into<Box<dyn StdError + Send + Sync>>,
 {
     fn call(
         &self,
         req: Request<Body>,
-    ) -> Pin<Box<dyn Future<Output = Result<Response<Body>>> + Send + Sync>> {
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync>> {
         Box::pin(self(req))
     }
 }
 
-impl fmt::Debug for dyn Handler {
+impl<E> fmt::Debug for dyn Handler<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "keiro::Handler")
     }
 }
 
 #[derive(Clone)]
-pub struct RouterService(Arc<Router>);
+pub struct RouterService<E: Into<Box<dyn StdError + Send + Sync>> + 'static>(Arc<Router<E>>);
 
-impl Service<Request<Body>> for RouterService {
+impl<E: Into<Box<dyn StdError + Send + Sync>> + 'static> Service<Request<Body>>
+    for RouterService<E>
+{
     type Response = Response<Body>;
-    type Error = Box<dyn StdError + Send + Sync>;
-    type Future = Pin<Box<dyn Future<Output = Result<Response<Body>>> + Send + Sync>>;
+    type Error = E;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Response<Body>, E>> + Send + Sync>>;
 
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<()>> {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), E>> {
         Poll::Ready(Ok(()))
     }
 
@@ -173,12 +214,13 @@ impl Service<Request<Body>> for RouterService {
     }
 }
 
-impl RouterService {
-    pub fn new(router: Router) -> Self {
+impl<E: Into<Box<dyn StdError + Send + Sync>>> RouterService<E> {
+    pub fn new(router: Router<E>) -> Self {
         Self(Arc::new(router))
     }
 }
 
+#[derive(Clone)]
 pub struct MakeRouterService<Svc> {
     pub inner: Svc,
 }
@@ -187,7 +229,7 @@ impl<T, Svc> Service<T> for MakeRouterService<Svc>
 where
     Svc: Service<Request<Body>> + Clone,
     Svc::Response: 'static,
-    Svc::Error: Into<Box<dyn StdError + Send + Sync>> + 'static,
+    Svc::Error: Into<Box<dyn StdError + Send + Sync>>,
     Svc::Future: 'static,
 {
     type Response = Svc;


### PR DESCRIPTION
```
➜  keiro git:(error_type) cargo check --example helloworld
    Checking keiro v0.0.1 (/Users/giraffate/workspace/keiro)
error[E0277]: the trait bound `(dyn std::error::Error + Send + Sync + 'static): Clone` is not satisfied
  --> examples/helloworld.rs:17:16
   |
17 |         .serve(router.into_service())
   |                ^^^^^^^^^^^^^^^^^^^^^
   |                |
   |                expected an implementor of trait `Clone`
   |                help: consider borrowing here: `&router.into_service()`
   |
   = note: required because of the requirements on the impl of `Clone` for `Box<(dyn std::error::Error + Send + Sync + 'static)>`
   = note: 1 redundant requirements hidden
   = note: required because of the requirements on the impl of `Clone` for `RouterService<Box<(dyn std::error::Error + Send + Sync + 'static)>>`
   = note: required because of the requirements on the impl of `Service<&'a AddrStream>` for `MakeRouterService<RouterService<Box<(dyn std::error::Error + Send + Sync + 'static)>>>`
   = note: required because of the requirements on the impl of `hyper::service::make::MakeServiceRef<AddrStream, Body>` for `MakeRouterService<RouterService<Box<(dyn std::error::Error + Send + Sync + 'static)>>>`

error[E0277]: the trait bound `(dyn std::error::Error + Send + Sync + 'static): Clone` is not satisfied
  --> examples/helloworld.rs:16:5
   |
16 | /     Server::bind(&addr)
17 | |         .serve(router.into_service())
18 | |         .await
   | |______________^ the trait `Clone` is not implemented for `(dyn std::error::Error + Send + Sync + 'static)`
   |
   = note: required because of the requirements on the impl of `Clone` for `Box<(dyn std::error::Error + Send + Sync + 'static)>`
   = note: 1 redundant requirements hidden
   = note: required because of the requirements on the impl of `Clone` for `RouterService<Box<(dyn std::error::Error + Send + Sync + 'static)>>`
   = note: required because of the requirements on the impl of `Service<&'a AddrStream>` for `MakeRouterService<RouterService<Box<(dyn std::error::Error + Send + Sync + 'static)>>>`
   = note: required because of the requirements on the impl of `hyper::service::make::MakeServiceRef<AddrStream, Body>` for `MakeRouterService<RouterService<Box<(dyn std::error::Error + Send + Sync + 'static)>>>`
   = note: required because of the requirements on the impl of `Future` for `Server<AddrIncoming, MakeRouterService<RouterService<Box<(dyn std::error::Error + Send + Sync + 'static)>>>>`
   = note: required by `poll`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0277`.
error: could not compile `keiro`

To learn more, run the command again with --verbose.
```